### PR TITLE
[BUG] Expried Jwt Token with Wrong Exception

### DIFF
--- a/src/main/java/ac/dnd/dodal/common/constant/Constants.java
+++ b/src/main/java/ac/dnd/dodal/common/constant/Constants.java
@@ -17,13 +17,14 @@ public class Constants {
     public static final String KAKAO_RESOURCE_SERVER_URL = "https://kapi.kakao.com/v2/user/me";
     public static final String APPLE_TOKEN_URL = "https://appleid.apple.com/auth/oauth2/v2/token";
 
-
+    /**
+     * Urls which don't need authentication
+     * but need to be filtered
+     * 
+     * @see JwtAuthenticationFilter
+     */
     public static final List<String> NO_NEED_AUTH_URLS = List.of(
 
-            //로그인 URL
-            //Swagger URL
-            //로그인 없이 둘러볼 수 있는 URL
-            "/hello",
             // 회원가입
             "/api/auth/sign-up",
             // 로그인
@@ -32,7 +33,19 @@ public class Constants {
             "/api/auth/login/kakao",
             "/api/auth/login/naver",
             "/api/auth/login/google",
-            "/api/auth/login/apple",
+            "/api/auth/login/apple"
+    );
+
+    /**
+     * Urls which bypass security filter so that it can be accessed without authentication
+     * Difference from NO_NEED_AUTH_URLS, NO_NEED_AUTH_URLS is 
+     * that they don't need to be authenticated but need to be filtered.
+     * 
+     * @see JwtAuthenticationFilter
+     */
+    public static final List<String> BYPASS_URLS = List.of(
+            // 
+            "/hello",
             // 모니터링 
             "/actuator/**",
             // 피드백 데이터 조회

--- a/src/main/java/ac/dnd/dodal/core/config/WebConfig.java
+++ b/src/main/java/ac/dnd/dodal/core/config/WebConfig.java
@@ -30,6 +30,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(this.userIdInterceptor)
                 .addPathPatterns("/**")
-                .excludePathPatterns(Constants.NO_NEED_AUTH_URLS);
+                .excludePathPatterns(Constants.NO_NEED_AUTH_URLS)
+                .excludePathPatterns(Constants.BYPASS_URLS);
     }
 }

--- a/src/main/java/ac/dnd/dodal/core/security/JwtAuthEntryPoint.java
+++ b/src/main/java/ac/dnd/dodal/core/security/JwtAuthEntryPoint.java
@@ -24,9 +24,11 @@ public class JwtAuthEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response,
                         AuthenticationException authException) throws IOException, ServletException {
 
+        authException.printStackTrace();
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        ApiResponse<Object> apiResponse = ApiResponse.failure(SecurityExceptionCode.ACCESS_DENIED_ERROR);
+        ApiResponse<Object> apiResponse = ApiResponse
+                .failure(SecurityExceptionCode.ACCESS_DENIED_ERROR, authException.getMessage());
         String jsonResponse = objectMapper.writeValueAsString(apiResponse);
         response.getWriter().write(jsonResponse);
     }

--- a/src/main/java/ac/dnd/dodal/core/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/ac/dnd/dodal/core/security/filter/JwtExceptionFilter.java
@@ -70,19 +70,16 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             setErrorResponse(response, SecurityExceptionCode.TOKEN_UNKNOWN_ERROR);
 
             return;
+        } catch (UserBadRequestException e) {
+            e.printStackTrace();
+            log.error("FilterException throw UserBadRequestException Exception : {}", e.getMessage());
+            setErrorResponse(response, e.getResultCode());
+
+            return;
         } catch (Exception e) {
-            // request에 저장된 예외 정보를 가져옴
-            Object exception = request.getAttribute("exception");
-            if (exception instanceof UserBadRequestException userException) {
-                setErrorResponse(response, userException.getResultCode());
-            } else if (exception instanceof SecurityExceptionCode securityCode) {
-                setErrorResponse(response, securityCode);
-            } else if (exception instanceof JwtException) {
-                setErrorResponse(response, SecurityExceptionCode.TOKEN_UNKNOWN_ERROR);
-            } else {
-                log.error("FilterException throw Exception Exception : {}", e.getMessage());
-                setErrorResponse(response, UserExceptionCode.NOT_FOUND_USER);
-            }
+            e.printStackTrace();
+            log.error("FilterException throw Exception Exception : {}", e.getMessage());
+            setErrorResponse(response, UserExceptionCode.NOT_FOUND_USER);
 
             return;
         }

--- a/src/main/resources/db/migration/V20__update_sample_refresh_token.sql
+++ b/src/main/resources/db/migration/V20__update_sample_refresh_token.sql
@@ -1,0 +1,1 @@
+update users set refresh_token = 'eyJhbGciOiJIUzUxMiJ9.eyJ1aWQiOjEsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzQwODIwNTc0LCJleHAiOjIwMjQ2NDQ1NzR9.YpyYaOtaNuz85cGeacU2OZScBz6jdlV5V8AxxBTSCF7Nis1CcHmHvp5bPeNOEvO219L7ce5yrvkHbUrG71uOIg' where user_id = 1;

--- a/src/test/java/ac/dnd/dodal/AcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/AcceptanceTest.java
@@ -25,9 +25,10 @@ public abstract class AcceptanceTest {
 
     protected static final Long userId = 1L;
     protected static final String userEmail = "test1@test.com";
-    protected static final String accessToken = "eyJhbGciOiJIUzUxMiJ9.eyJ1aWQiOjEsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzM5MzA4OTc1LCJleHAiOjE3NDAxODc4NTl9.7nH4G9T2PW9AI7JTCm7RteiechdLWsoeWanh4kX-Yt6UQ4qQVhohXlpA7DYR9fZZwjiyn7GLN73m1LXsNT1Djw";
+    protected static final String accessToken =
+            "eyJhbGciOiJIUzUxMiJ9.eyJ1aWQiOjEsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzQwODIwNTc0LCJleHAiOjIwMjQ2NDQ1NzR9.YpyYaOtaNuz85cGeacU2OZScBz6jdlV5V8AxxBTSCF7Nis1CcHmHvp5bPeNOEvO219L7ce5yrvkHbUrG71uOIg";
     protected static final String refreshToken =
-            "eyJhbGciOiJIUzUxMiJ9.eyJ1aWQiOjEsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzM5MzA4OTc1LCJleHAiOjE3NDAxODc4NTl9.7nH4G9T2PW9AI7JTCm7RteiechdLWsoeWanh4kX-Yt6UQ4qQVhohXlpA7DYR9fZZwjiyn7GLN73m1LXsNT1Djw";
+            "eyJhbGciOiJIUzUxMiJ9.eyJ1aWQiOjEsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzQwODIwNTc0LCJleHAiOjIwMjQ2NDQ1NzR9.YpyYaOtaNuz85cGeacU2OZScBz6jdlV5V8AxxBTSCF7Nis1CcHmHvp5bPeNOEvO219L7ce5yrvkHbUrG71uOIg";
 
     protected static final Long userId2 = 2L;
     protected static final String userEmail2 = "test2@test.com";

--- a/src/test/java/ac/dnd/dodal/acceptance/auth/refreshAccessTokenAcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/auth/refreshAccessTokenAcceptanceTest.java
@@ -17,39 +17,39 @@ import org.springframework.http.HttpStatus;
 
 public class refreshAccessTokenAcceptanceTest extends AcceptanceTest {
 
-  @Test
-  @DisplayName("Refresh Access Token Test")
-  public void refresh_access_token() {
-    // when
-    Response response = AuthSteps.refreshAccessToken(refreshAuthorizationHeader);
-    ApiResponse<UserInfoResponseDto> apiResponse = response.as(new TypeRef<ApiResponse<UserInfoResponseDto>>() {});
-    UserInfoResponseDto userInfoResponseDto = apiResponse.data();
-    JwtTokenDto jwtTokenDto = userInfoResponseDto.jwtTokenDto();
-    // then 200
-    assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    // COM001
-    assertThat(apiResponse.code()).isEqualTo(CommonResultCode.SUCCESS.getCode());
-    // Success
-    assertThat(apiResponse.message()).isEqualTo(CommonResultCode.SUCCESS.getMessage());
-    // data
-    assertThat(response.getBody().jsonPath().getMap("data").get("email")).isEqualTo(userEmail);
-    assertThat(jwtTokenDto.accessToken()).isNotNull();
-    assertThat(jwtTokenDto.refreshToken()).isNotNull();
-  }
+    @Test
+    @DisplayName("Refresh Access Token Test")
+    public void refresh_access_token() {
+        // when
+        Response response = AuthSteps.refreshAccessToken(refreshAuthorizationHeader);
+        ApiResponse<UserInfoResponseDto> apiResponse =
+            response.as(new TypeRef<ApiResponse<UserInfoResponseDto>>() {});
+        UserInfoResponseDto userInfoResponseDto = apiResponse.data();
+        JwtTokenDto jwtTokenDto = userInfoResponseDto.jwtTokenDto();
+        // then 200
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        // COM001
+        assertThat(apiResponse.code()).isEqualTo(CommonResultCode.SUCCESS.getCode());
+        // Success
+        assertThat(apiResponse.message()).isEqualTo(CommonResultCode.SUCCESS.getMessage());
+        // data
+        assertThat(response.getBody().jsonPath().getMap("data").get("email")).isEqualTo(userEmail);
+        assertThat(jwtTokenDto.accessToken()).isNotNull();
+        assertThat(jwtTokenDto.refreshToken()).isNotNull();
+    }
 
-  @Test
-  @DisplayName("Refresh Access Token Test with Unauthorized Refresh Token")
+    @Test
+    @DisplayName("Refresh Access Token Test with Unauthorized Refresh Token")
     public void refresh_access_token_with_unauthorized_refresh_token() {
         // when
         Response response = AuthSteps.refreshAccessToken(unauthorizedRefreshAuthorizationHeader);
-        ApiResponse<UserInfoResponseDto> apiResponse = response.as(new TypeRef<ApiResponse<UserInfoResponseDto>>() {});
+        ApiResponse<UserInfoResponseDto> apiResponse =
+            response.as(new TypeRef<ApiResponse<UserInfoResponseDto>>() {});
         // then 401
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
         // COM002
         assertThat(apiResponse.code()).isEqualTo(SecurityExceptionCode.ACCESS_DENIED_ERROR.getCode());
-        // Unauthorized
-        assertThat(apiResponse.message()).isEqualTo(SecurityExceptionCode.ACCESS_DENIED_ERROR.getMessage());
         // data does not exist
         assertThat(response.getBody().jsonPath().getMap("data")).isNull();
     }
-}
+  }

--- a/src/test/java/ac/dnd/dodal/acceptance/onboarding/GetOnBoardingDataAcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/onboarding/GetOnBoardingDataAcceptanceTest.java
@@ -45,11 +45,11 @@ public class GetOnBoardingDataAcceptanceTest extends AcceptanceTest {
 
         // then 403
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-        // SEC009
-        assertThat(apiResponse.code()).isEqualTo(SecurityExceptionCode.ACCESS_DENIED_ERROR.getCode());
-        // Fail
+        // SEC001
+        assertThat(apiResponse.code()).isEqualTo(SecurityExceptionCode.TOKEN_MALFORMED_ERROR.getCode());
+        // Token Malformed Error
         assertThat(apiResponse.message())
-                .isEqualTo(SecurityExceptionCode.ACCESS_DENIED_ERROR.getMessage());
+                .isEqualTo(SecurityExceptionCode.TOKEN_MALFORMED_ERROR.getMessage());
         // data exist
         assertThat(apiResponse.data()).isNull();
     }

--- a/src/test/java/ac/dnd/dodal/application/plan/service/PlanCommandServiceTest.java
+++ b/src/test/java/ac/dnd/dodal/application/plan/service/PlanCommandServiceTest.java
@@ -37,6 +37,7 @@ import ac.dnd.dodal.domain.plan.event.PlanCompletedEvent;
 import ac.dnd.dodal.domain.plan_history.model.PlanHistory;
 import ac.dnd.dodal.domain.plan_history.PlanHistoryFixture;
 import ac.dnd.dodal.domain.plan_history.exception.PlanHistoryExceptionCode;
+import ac.dnd.dodal.domain.plan_history.model.HistoryStatistics;
 import ac.dnd.dodal.application.plan.dto.command.*;
 import ac.dnd.dodal.application.plan_feedback.service.PlanFeedbackService;
 import ac.dnd.dodal.application.plan.dto.CompletePlanCommandFixture;
@@ -44,6 +45,7 @@ import ac.dnd.dodal.application.goal.dto.AddPlanCommandFixture;
 import ac.dnd.dodal.application.goal.service.GoalService;
 import ac.dnd.dodal.application.plan_history.service.PlanHistoryService;
 import ac.dnd.dodal.application.user_guide.service.UserGuideService;
+import ac.dnd.dodal.application.plan_history.service.HistoryStatisticsService;
 
 @ExtendWith(MockitoExtension.class)
 public class PlanCommandServiceTest {
@@ -62,6 +64,9 @@ public class PlanCommandServiceTest {
 
     @Mock
     private UserGuideService userGuideService;
+
+    @Mock
+    private HistoryStatisticsService historyStatisticsService;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
@@ -212,6 +217,7 @@ public class PlanCommandServiceTest {
 
         // then
         verify(planService).save(any(Plan.class));
+        verify(historyStatisticsService).save(any(HistoryStatistics.class));
     }
 
     @Test

--- a/src/test/java/ac/dnd/dodal/core/security/util/JwtUtilTest.java
+++ b/src/test/java/ac/dnd/dodal/core/security/util/JwtUtilTest.java
@@ -5,8 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import io.jsonwebtoken.Claims;
+
 import ac.dnd.dodal.IntegrationTest;
 import ac.dnd.dodal.domain.user.enums.UserRole;
+import ac.dnd.dodal.common.constant.Constants;
 
 public class JwtUtilTest extends IntegrationTest {
 
@@ -17,15 +20,19 @@ public class JwtUtilTest extends IntegrationTest {
     String deviceToken = "device_token1";
     String nickname = "test1";
 
-    long millisecondsIn999Years = 999 * 365 * 24 * 60 * 60 * 1000; // 31,536,000,000,000
+    long millisecondsIn999Years = 9 * 365 * 24 * 60 * 60 * 1000L; // 31,536,000,000,000
     Long expirationPeriod = millisecondsIn999Years;
 
     @Test
     @DisplayName("Create JWT Token Success")
     public void create_jwt_token() {
+        // when
         String token = jwtUtil.createToken(userId, userRole, expirationPeriod);
-        System.out.println("Create JWT Token (999Years) = " + token);
 
-        assertThat(userId).isEqualTo(jwtUtil.getUserIdFromToken(token));
+        // then
+        Claims claims = jwtUtil.validateAndGetClaimsFromToken(token);
+        assertThat(userId).isEqualTo(claims.get(Constants.USER_ID_CLAIM_NAME, Long.class));
+        assertThat(userRole.name()).isEqualTo(
+            claims.get(Constants.USER_ROLE_CLAIM_NAME, String.class));
     }
 }


### PR DESCRIPTION
## 📝 Purpose of PR

기존에 999y의 유효기간으로 설정한 UserId 1의 access token이 access denied가 뜨는 상황을 해결한다.

## Contents

### Issue 1. Int Overflow
- millisecond로 expiration을 설정하는데, 저장은 Long이지만 연산은 int로 수행되어 곱셈 도중 오버플로우 발생 -> 예상치 못한 값 저장되는 문제 발생
### Issue 2. No use of JwtFilterException
- JwtAutenticationFilter에서 발생하는 에러는 모두 JwtEntryPoint에서 AuthException으로 처리하도록 설정되어 있었음
  - 해당 예외에 대한 정보를 사용하지 x -> Security Filter에서 발생하는 모든 에러가 SEC009와 ACCESS_DENIED_ERROR로 통일되어 반환되고 있는 상황
  - Jwt관련 에러 (JwtException, UserBadRequest-custom exception)의 경우 doFilter로 다음 필터로 넘기는 것이 아닌 re-throw하여 ExceptionFilter가 catch하도록 수정 -> JwtExceptionFilter에서 각 예외에 맞게 response 설정
