### PR TITLE
[FEAT] Delete Plan

### DIFF
--- a/src/main/java/ac/dnd/dodal/application/plan/dto/command/DeletePlanCommand.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/dto/command/DeletePlanCommand.java
@@ -1,0 +1,7 @@
+package ac.dnd.dodal.application.plan.dto.command;
+
+public record DeletePlanCommand(
+    Long userId,
+    Long planId
+) {
+}

--- a/src/main/java/ac/dnd/dodal/application/plan/service/PlanCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/service/PlanCommandService.java
@@ -108,7 +108,7 @@ public class PlanCommandService implements
         UserType userType = UserType.of(userTypeGuide.getContent());
         String guide =
                 GuidianceGenerator.generateUpdatePlanGuide(userType, feedback.getIndicator());
-
+ 
         plan.getGoal().completePlan(command.userId(), command.status(), plan, feedbacks, guide);
 
         eventPublisher.publishEvent(PlanCompletedEvent.of(plan, feedback));
@@ -127,7 +127,12 @@ public class PlanCommandService implements
         }
         plan.delete();
         planService.save(plan);
-        eventPublisher.publishEvent(new DeletedPlanEvent(plan.getPlanId(), command.userId()));
+        eventPublisher.publishEvent(
+                new DeletedPlanEvent(
+                        plan.getPlanId(),
+                        plan.getHistory().getHistoryId(), 
+                        command.userId(), 
+                        plan.getStatus()));
     }
 
     private List<Plan> generateIterationPlans(AddSamePlanCommand command, Plan plan) {

--- a/src/main/java/ac/dnd/dodal/application/plan/usecase/DeletePlanUseCase.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/usecase/DeletePlanUseCase.java
@@ -1,7 +1,9 @@
 package ac.dnd.dodal.application.plan.usecase;
 
+import ac.dnd.dodal.application.plan.dto.command.DeletePlanCommand;
+
 public interface DeletePlanUseCase {
 
-    void delete(Long planId, Long userId);
+    void delete(DeletePlanCommand command);
 }
 

--- a/src/main/java/ac/dnd/dodal/application/plan/usecase/DeletePlanUseCase.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/usecase/DeletePlanUseCase.java
@@ -1,0 +1,7 @@
+package ac.dnd.dodal.application.plan.usecase;
+
+public interface DeletePlanUseCase {
+
+    void delete(Long planId, Long userId);
+}
+

--- a/src/main/java/ac/dnd/dodal/application/plan_history/service/HistoryStatisticsEventListenter.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/service/HistoryStatisticsEventListenter.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 
 import ac.dnd.dodal.domain.plan_history.model.HistoryStatistics;
 import ac.dnd.dodal.domain.plan.event.PlanCompletedEvent;
+import ac.dnd.dodal.domain.plan.event.DeletedPlanEvent;
+import ac.dnd.dodal.domain.plan.enums.PlanStatus;
 
 @Component
 @RequiredArgsConstructor
@@ -17,10 +19,23 @@ public class HistoryStatisticsEventListenter {
     @EventListener
     public void handlePlanCompletedEvent(PlanCompletedEvent event) {
         HistoryStatistics historyStatistics =
-            historyStatisticsService.findByIdOrThrow(event.getHistoryId());
+                historyStatisticsService.findByIdOrThrow(event.getHistoryId());
 
         historyStatistics.incrementCount(event.getStatus());
         historyStatistics.setRecentCompletedPlanTitle(event.getTitle());
+        historyStatisticsService.save(historyStatistics);
+    }
+
+    @EventListener
+    public void handleDeletedPlanEvent(DeletedPlanEvent event) {
+        if (event.getStatus() == PlanStatus.NONE) {
+            return;
+        }
+        HistoryStatistics historyStatistics =
+                historyStatisticsService.findByIdOrThrow(event.getHistoryId());
+
+        // TODO: 가장 최근 완료된 Plan인 경우 title도 다시 바꿔야한다...
+        historyStatistics.decrementCount(event.getStatus());
         historyStatisticsService.save(historyStatistics);
     }
 }

--- a/src/main/java/ac/dnd/dodal/domain/plan/event/DeletedPlanEvent.java
+++ b/src/main/java/ac/dnd/dodal/domain/plan/event/DeletedPlanEvent.java
@@ -1,0 +1,18 @@
+package ac.dnd.dodal.domain.plan.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.EqualsAndHashCode;
+
+import ac.dnd.dodal.domain.plan.enums.PlanStatus;
+
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor
+public class DeletedPlanEvent {
+
+    private final Long planId;
+    private final Long historyId;
+    private final Long userId;
+    private final PlanStatus status;
+}

--- a/src/main/java/ac/dnd/dodal/domain/plan/event/PlanCompletedEvent.java
+++ b/src/main/java/ac/dnd/dodal/domain/plan/event/PlanCompletedEvent.java
@@ -21,6 +21,7 @@ public class PlanCompletedEvent {
     private String guide;
     private String title;
 
+    // TODO: 이렇게 가져오면 안됨!!!!!!!! 로직 개선 필수
     public static PlanCompletedEvent of(Plan plan, PlanFeedback feedback) {
         return new PlanCompletedEvent(
             plan.getGoal().getUserId(),

--- a/src/main/java/ac/dnd/dodal/domain/plan/model/Plan.java
+++ b/src/main/java/ac/dnd/dodal/domain/plan/model/Plan.java
@@ -133,6 +133,13 @@ public class Plan extends BaseEntity {
         return this.status != PlanStatus.NONE || this.completedDate != null;
     }
 
+    public void delete() {
+        if (this.deletedAt != null) {
+            throw new BadRequestException(PlanExceptionCode.PLAN_ALREADY_DELETED);
+        }
+        super.delete();
+    }
+
     private void validateTitle(String title) {
         if (title == null || title.isEmpty()) {
             throw new BadRequestException(PlanExceptionCode.PLAN_TITLE_EMPTY);

--- a/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
+++ b/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
@@ -16,6 +16,7 @@ import ac.dnd.dodal.domain.plan.model.Plan;
 import ac.dnd.dodal.domain.plan.enums.PlanStatus;
 import ac.dnd.dodal.application.plan.usecase.CompletePlanUseCase;
 import ac.dnd.dodal.application.plan.usecase.DeletePlanUseCase;
+import ac.dnd.dodal.application.plan.dto.command.DeletePlanCommand;
 import ac.dnd.dodal.ui.feedback.request.CreateFeedbackRequest;
 import ac.dnd.dodal.ui.plan.response.PlanElement;
 
@@ -44,7 +45,7 @@ public class PlanController {
         @UserId Long userId,
         @PathVariable Long planId
     ) {
-        deletePlanUseCase.delete(planId, userId);
+        deletePlanUseCase.delete(new DeletePlanCommand(userId, planId));
 
         return ApiResponse.success();
     }

--- a/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
+++ b/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 import ac.dnd.dodal.common.annotation.UserId;
 import ac.dnd.dodal.common.response.ApiResponse;
@@ -34,5 +35,13 @@ public class PlanController {
         Plan plan = completePlanUseCase.completePlan(request.toCommand(userId, planId, PlanStatus.of(status)));
 
         return ApiResponse.success(PlanElement.of(plan));
+    }
+
+    @DeleteMapping("/{planId}")
+    public ApiResponse<Void> deletePlan(
+        @UserId Long userId,
+        @PathVariable Long planId
+    ) {
+        return ApiResponse.success();
     }
 }

--- a/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
+++ b/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
@@ -15,6 +15,7 @@ import ac.dnd.dodal.common.response.ApiResponse;
 import ac.dnd.dodal.domain.plan.model.Plan;
 import ac.dnd.dodal.domain.plan.enums.PlanStatus;
 import ac.dnd.dodal.application.plan.usecase.CompletePlanUseCase;
+import ac.dnd.dodal.application.plan.usecase.DeletePlanUseCase;
 import ac.dnd.dodal.ui.feedback.request.CreateFeedbackRequest;
 import ac.dnd.dodal.ui.plan.response.PlanElement;
 
@@ -24,6 +25,7 @@ import ac.dnd.dodal.ui.plan.response.PlanElement;
 public class PlanController {
 
     private final CompletePlanUseCase completePlanUseCase;
+    private final DeletePlanUseCase deletePlanUseCase;
 
     @PostMapping("/{planId}/complete")
     public ApiResponse<?> completePlan(
@@ -42,6 +44,8 @@ public class PlanController {
         @UserId Long userId,
         @PathVariable Long planId
     ) {
+        deletePlanUseCase.delete(planId, userId);
+
         return ApiResponse.success();
     }
 }

--- a/src/test/java/ac/dnd/dodal/acceptance/plan/PlanCompleteAcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan/PlanCompleteAcceptanceTest.java
@@ -23,7 +23,7 @@ import ac.dnd.dodal.domain.plan.exception.PlanExceptionCode;
 import ac.dnd.dodal.ui.plan.response.PlanElement;
 
 @Slf4j
-public class PlanAcceptanceTest extends AcceptanceTest {
+public class PlanCompleteAcceptanceTest extends AcceptanceTest {
 
     private static final String SUCCESS_STATUS = "success";
     private static final String FAILURE_STATUS = "failure";

--- a/src/test/java/ac/dnd/dodal/acceptance/plan/PlanDeleteAcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan/PlanDeleteAcceptanceTest.java
@@ -1,0 +1,42 @@
+package ac.dnd.dodal.acceptance.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.Response;
+
+import ac.dnd.dodal.AcceptanceTest;
+import ac.dnd.dodal.acceptance.plan.steps.PlanSteps;
+import ac.dnd.dodal.common.enums.CommonResultCode;
+import ac.dnd.dodal.common.response.ApiResponse;
+
+public class PlanDeleteAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    @DisplayName("Plan Delete Test")
+    void plan_delete_test() {
+        // given
+        Map<String, Object> header = authorizationHeader;
+
+        // when
+        Response response = PlanSteps.deletePlan(planId, header);
+        ApiResponse<Void> apiResponse = response.as(new TypeRef<ApiResponse<Void>>() {});
+
+        log.info("response = {}", response.asString());
+
+        // then 200
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        // then COM000
+        assertThat(apiResponse.code()).isEqualTo(CommonResultCode.SUCCESS.getCode());
+        // then Success
+        assertThat(apiResponse.message()).isEqualTo(CommonResultCode.SUCCESS.getMessage());
+        // then data null
+        assertThat(apiResponse.data()).isNull();
+    }
+}

--- a/src/test/java/ac/dnd/dodal/acceptance/plan/steps/PlanSteps.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan/steps/PlanSteps.java
@@ -11,7 +11,9 @@ import ac.dnd.dodal.ui.feedback.request.CreateFeedbackRequest;
 
 public class PlanSteps {
     
-    private static final String COMPLETE_PLAN_URL = "/api/plans/{planId}/complete?status={status}";
+    private static final String BASE_URL = "/api/plans";
+    private static final String COMPLETE_PLAN_URL = BASE_URL + "/{planId}/complete?status={status}";
+    private static final String DELETE_PLAN_URL = BASE_URL + "/{planId}";
 
     public static Response completePlan(Long planId, String status,
             Map<String, Object> header, CreateFeedbackRequest request) {
@@ -28,5 +30,19 @@ public class PlanSteps {
             .then().log().all()
                 .extract()
                 .response();
+    }
+
+    public static Response deletePlan(Long planId, Map<String, Object> header) {
+        String url = DELETE_PLAN_URL
+            .replace("{planId}", planId.toString());
+
+        return given().log().all()
+                .contentType(ContentType.JSON)
+                .headers(header)
+            .when()
+                .delete(url)
+            .then().log().all()
+                .extract()
+            .response();
     }
 }

--- a/src/test/java/ac/dnd/dodal/application/plan/service/PlanCommandServiceTest.java
+++ b/src/test/java/ac/dnd/dodal/application/plan/service/PlanCommandServiceTest.java
@@ -34,6 +34,7 @@ import ac.dnd.dodal.domain.plan.exception.PlanExceptionCode;
 import ac.dnd.dodal.domain.plan.model.Plan;
 import ac.dnd.dodal.domain.plan.PlanFixture;
 import ac.dnd.dodal.domain.plan.event.PlanCompletedEvent;
+import ac.dnd.dodal.domain.plan.event.DeletedPlanEvent;
 import ac.dnd.dodal.domain.plan_history.model.PlanHistory;
 import ac.dnd.dodal.domain.plan_history.PlanHistoryFixture;
 import ac.dnd.dodal.domain.plan_history.exception.PlanHistoryExceptionCode;
@@ -46,7 +47,6 @@ import ac.dnd.dodal.application.goal.service.GoalService;
 import ac.dnd.dodal.application.plan_history.service.PlanHistoryService;
 import ac.dnd.dodal.application.user_guide.service.UserGuideService;
 import ac.dnd.dodal.application.plan_history.service.HistoryStatisticsService;
-
 @ExtendWith(MockitoExtension.class)
 public class PlanCommandServiceTest {
 
@@ -368,9 +368,10 @@ public class PlanCommandServiceTest {
         when(planService.findByIdOrThrow(command.planId())).thenReturn(successPlan);
 
         // when
-        planCommandService.delete(command.planId(), command.userId());
+        planCommandService.delete(command);
 
         // then
         verify(planService).save(any(Plan.class));
+        verify(eventPublisher).publishEvent(any(DeletedPlanEvent.class));
     }
 }

--- a/src/test/java/ac/dnd/dodal/application/plan/service/PlanCommandServiceTest.java
+++ b/src/test/java/ac/dnd/dodal/application/plan/service/PlanCommandServiceTest.java
@@ -346,18 +346,31 @@ public class PlanCommandServiceTest {
     public void complete_failure_plan_failure_by_plan_not_started() {
         // given
         CompletePlanCommand command = CompletePlanCommandFixture.failurePlanCommand();
-        UserGuide userType = new UserGuide
-            (userId, GuideType.USER_TYPE, UserType.GOAL_ORIENTED.getValue());
+        UserGuide userType =
+                new UserGuide(userId, GuideType.USER_TYPE, UserType.GOAL_ORIENTED.getValue());
         uncompletedPlan.setGoal(goal);
         uncompletedPlan.setHistory(planHistory);
         when(planService.findByIdOrThrow(command.planId())).thenReturn(notStartedPlan);
         when(userGuideService.findByUserIdAndTypeOrThrow(userId, GuideType.USER_TYPE))
-            .thenReturn(userType);
+                .thenReturn(userType);
 
         // when & then
         assertThatThrownBy(() -> planCommandService.completePlan(command))
-                        .isInstanceOf(BadRequestException.class)
-                        .hasMessage(PlanExceptionCode.PLAN_SUCCEED_AFTER_START_DATE
-                        .getMessage());
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(PlanExceptionCode.PLAN_SUCCEED_AFTER_START_DATE.getMessage());
+    }
+
+    @Test
+    @DisplayName("Delete plan success")
+    public void delete_plan_success() {
+        // given
+        DeletePlanCommand command = new DeletePlanCommand(userId, planId);
+        when(planService.findByIdOrThrow(command.planId())).thenReturn(successPlan);
+
+        // when
+        planCommandService.delete(command.planId(), command.userId());
+
+        // then
+        verify(planService).save(any(Plan.class));
     }
 }


### PR DESCRIPTION
DeletedPlan을 생성하여 HistoryStatistics에서 count 업데이트 수행

### 해야하는 일
- Plan에서 해당 user가 맞는지 검증하는 게 Goal을 추가적으로 조회하여 그 안의 user id를 조회하는 방식임 -> Aggregate root를 정말 잘 쓰거나, 아니면 Plan에 user id를 추가해야한다
- 이외에도 연관된 필드를 추가 조회하는 경우가 많은데, 이에 대한 개선이 필요하다
- Plan에서 user 검증 로직이 아예 없는 경우가 많다 -> 추가해야한다
- Eventlistener에 대한 테스트가 존재하지 않는다.