### PR TITLE
[FEAT] Get Plan API

### DIFF
--- a/src/main/java/ac/dnd/dodal/application/plan/dto/command/CompletePlanCommand.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/dto/command/CompletePlanCommand.java
@@ -25,13 +25,12 @@ public record CompletePlanCommand(
             throw new IllegalArgumentException(
                     "CompletePlanCommand: only SUCCESS or FAILURE status is allowed");
         }
-        // TODO: MVP 배포 후 직접 입력 받는 것으로 수정
-        // if (question == null || question.isEmpty()) {
-        //     throw new IllegalArgumentException("CompletePlanCommand: question is required");
-        // }
-        // if (indicator == null || indicator.isEmpty()) {
-        //     throw new IllegalArgumentException("CompletePlanCommand: indicator is required");
-        // }
+        if (question == null || question.isEmpty()) {
+            throw new IllegalArgumentException("CompletePlanCommand: question is required");
+        }
+        if (indicator == null || indicator.isEmpty()) {
+            throw new IllegalArgumentException("CompletePlanCommand: indicator is required");
+        }
         this.userId = userId;
         this.planId = planId;
         this.status = status;

--- a/src/main/java/ac/dnd/dodal/application/plan/dto/query/GetPlanQuery.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/dto/query/GetPlanQuery.java
@@ -1,0 +1,8 @@
+package ac.dnd.dodal.application.plan.dto.query;
+
+public record GetPlanQuery(
+    Long userId,
+    Long planId
+) {
+    
+}

--- a/src/main/java/ac/dnd/dodal/application/plan/repository/PlanRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/repository/PlanRepository.java
@@ -80,7 +80,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
             + "WHERE p2.planId = :planId "
             + "AND p2.goal.userId = :userId "
             + "AND p2.deletedAt IS NULL) "
-            + "AND p.completedDate < (SELECT p3.completedDate FROM plans p3 "
+            + "AND p.completedDate <= (SELECT p3.completedDate FROM plans p3 "
             + "WHERE p3.planId = :planId "
             + "AND p3.deletedAt IS NULL) "
             + "AND p.deletedAt IS NULL "

--- a/src/main/java/ac/dnd/dodal/application/plan/service/PlanCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/service/PlanCommandService.java
@@ -95,20 +95,18 @@ public class PlanCommandService implements
         planService.save(plan);
     }
 
-    // TODO: MVP 배포 후 직접 입력 받는 것으로 수정
     @Override
     public List<PlanElement> completePlan(CompletePlanCommand command) {
         Plan plan = planService.findByIdOrThrow(command.planId());
         List<PlanFeedback> feedbacks = new ArrayList<>();
-//         PlanFeedback feedback = new PlanFeedback(command.question(), command.indicator());
-        PlanFeedback feedback = new PlanFeedback("조금 더 수월하게 달성하기 위해 무엇을 바꿔볼까요?", "우선 순위를 재조정해요.");
+        PlanFeedback feedback = new PlanFeedback(command.question(), command.indicator());
         feedbacks.add(feedback);
         UserGuide userTypeGuide =
                 userGuideService.findByUserIdAndTypeOrThrow(command.userId(), GuideType.USER_TYPE);
         UserType userType = UserType.of(userTypeGuide.getContent());
         String guide =
                 GuidianceGenerator.generateUpdatePlanGuide(userType, feedback.getIndicator());
- 
+
         plan.getGoal().completePlan(command.userId(), command.status(), plan, feedbacks, guide);
 
         eventPublisher.publishEvent(PlanCompletedEvent.of(plan, feedback));
@@ -119,7 +117,7 @@ public class PlanCommandService implements
         // 가장 오래된 계획과 개선할 점 을 두 개와 방금 완료한 계획 출력
         return planService.findOlderAndNowByHistoryIdOrThrow(plan.getHistory().getHistoryId(), plan.getPlanId());
     }
-    
+
     @Override
     public void delete(DeletePlanCommand command) {
         Plan plan = planService.findByIdOrThrow(command.planId());

--- a/src/main/java/ac/dnd/dodal/application/plan/service/PlanCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/service/PlanCommandService.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import ac.dnd.dodal.application.plan_history.service.HistoryStatisticsService;
 import ac.dnd.dodal.domain.plan_history.model.HistoryStatistics;
-import ac.dnd.dodal.ui.plan.response.PlanElement;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -96,7 +95,7 @@ public class PlanCommandService implements
     }
 
     @Override
-    public List<PlanElement> completePlan(CompletePlanCommand command) {
+    public Plan completePlan(CompletePlanCommand command) {
         Plan plan = planService.findByIdOrThrow(command.planId());
         List<PlanFeedback> feedbacks = new ArrayList<>();
         PlanFeedback feedback = new PlanFeedback(command.question(), command.indicator());
@@ -112,10 +111,7 @@ public class PlanCommandService implements
         eventPublisher.publishEvent(PlanCompletedEvent.of(plan, feedback));
         planFeedbackService.saveAll(feedbacks);
         userGuideService.updateUpdatePlanGuide(command.userId(), guide);
-        planService.save(plan);
-
-        // 가장 오래된 계획과 개선할 점 을 두 개와 방금 완료한 계획 출력
-        return planService.findOlderAndNowByHistoryIdOrThrow(plan.getHistory().getHistoryId(), plan.getPlanId());
+        return planService.save(plan);
     }
 
     @Override

--- a/src/main/java/ac/dnd/dodal/application/plan/service/PlanQueryService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/service/PlanQueryService.java
@@ -17,9 +17,11 @@ import ac.dnd.dodal.application.plan.repository.PlanRepository;
 import ac.dnd.dodal.application.plan.usecase.GetPlansOfHistoryUseCase;
 import ac.dnd.dodal.application.plan.usecase.GetPlansOfGoalByDateUseCase;
 import ac.dnd.dodal.application.plan.usecase.GetWeeklyAchievementRateOfGoalUseCase;
+import ac.dnd.dodal.application.plan.usecase.GetPlanUseCase;
 import ac.dnd.dodal.application.plan.dto.query.GetPlansOfHistoryQuery;
 import ac.dnd.dodal.application.plan.dto.query.GetPlansOfGoalQuery;
 import ac.dnd.dodal.application.plan.dto.query.GetWeeklyAchievementRateOfGoalQuery;
+import ac.dnd.dodal.application.plan.dto.query.GetPlanQuery;
 import ac.dnd.dodal.application.plan.dto.PlanModel;
 import ac.dnd.dodal.ui.plan.response.PlanElement;
 import ac.dnd.dodal.ui.goal.response.DailyAchievementRateElement;
@@ -29,10 +31,18 @@ import ac.dnd.dodal.ui.goal.response.DailyAchievementRateElement;
 public class PlanQueryService implements 
     GetPlansOfHistoryUseCase, 
     GetPlansOfGoalByDateUseCase,
-    GetWeeklyAchievementRateOfGoalUseCase {
+    GetWeeklyAchievementRateOfGoalUseCase,
+    GetPlanUseCase {
 
     private final PlanRepository planRepository;
     private final PlanService planService;
+
+    private final int PLAN_HISTORY_CHUNK_SIZE = 3;
+
+    @Override
+    public List<PlanElement> getPlanHistory(GetPlanQuery query) {
+        return planRepository.findHistoriesByPlanId(query.planId(), query.userId(), PLAN_HISTORY_CHUNK_SIZE);
+    }
 
     @Override
     public Page<PlanElement> getPlansOfHistory(GetPlansOfHistoryQuery query) {

--- a/src/main/java/ac/dnd/dodal/application/plan/service/PlanService.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/service/PlanService.java
@@ -3,7 +3,6 @@ package ac.dnd.dodal.application.plan.service;
 import java.util.List;
 import java.util.Optional;
 
-import ac.dnd.dodal.ui.plan.response.PlanElement;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -56,9 +55,5 @@ public class PlanService {
 
     public boolean isExistByUserIdAndGoalId(Long userId, Long goalId) {
         return planRepository.isExistByUserIdAndGoalId(userId, goalId);
-    }
-
-    public List<PlanElement> findOlderAndNowByHistoryIdOrThrow(Long historyId, Long id) {
-        return planRepository.findOlderAndNowByHistoryId(historyId, id);
     }
 }

--- a/src/main/java/ac/dnd/dodal/application/plan/usecase/CompletePlanUseCase.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/usecase/CompletePlanUseCase.java
@@ -2,11 +2,8 @@ package ac.dnd.dodal.application.plan.usecase;
 
 import ac.dnd.dodal.application.plan.dto.command.CompletePlanCommand;
 import ac.dnd.dodal.domain.plan.model.Plan;
-import ac.dnd.dodal.ui.plan.response.PlanElement;
-
-import java.util.List;
 
 public interface CompletePlanUseCase {
 
-    List<PlanElement> completePlan(CompletePlanCommand command);
+    Plan completePlan(CompletePlanCommand command);
 }

--- a/src/main/java/ac/dnd/dodal/application/plan/usecase/GetPlanUseCase.java
+++ b/src/main/java/ac/dnd/dodal/application/plan/usecase/GetPlanUseCase.java
@@ -1,0 +1,11 @@
+package ac.dnd.dodal.application.plan.usecase;
+
+import java.util.List;
+
+import ac.dnd.dodal.application.plan.dto.query.GetPlanQuery;
+import ac.dnd.dodal.ui.plan.response.PlanElement;
+
+public interface GetPlanUseCase {
+
+    List<PlanElement> getPlanHistory(GetPlanQuery query);
+}

--- a/src/main/java/ac/dnd/dodal/domain/feedback/enums/FeedbackIndicator.java
+++ b/src/main/java/ac/dnd/dodal/domain/feedback/enums/FeedbackIndicator.java
@@ -1,0 +1,36 @@
+package ac.dnd.dodal.domain.feedback.enums;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FeedbackIndicator {
+
+    // SUCCESS
+    REORGANIZE_PRIORITIES(FeedbackType.SUCCESS, "우선 순위를 재조정해요."),
+    TRY_TIME_SAVING(FeedbackType.SUCCESS, "시간 단축을 시도해볼래요."),
+    CHECK_PLAN_ACCURACY(FeedbackType.SUCCESS, "계획 정확도를 점검해요."),
+    CHECK_PROGRESS(FeedbackType.SUCCESS, "진행 상황을 더 꼼꼼히 확인해요."),
+    ANALYZE_PATTERN(FeedbackType.SUCCESS, "스스로 패턴을 분석해봐요."),
+
+    // FAILURE
+    SIMPLIFY_STEPS(FeedbackType.FAILURE, "계획을 더 쉽게 설정해요."),
+    SPECIFY_PLAN(FeedbackType.FAILURE, "구체적인 계획을 설정해요."),
+    CHECK_PROGRESS_REGULARLY(FeedbackType.FAILURE, "진행상황을 수시로 확인해요."),
+    ALLOCATE_MORE_TIME(FeedbackType.FAILURE, "계획 실행 시간을 좀 더 확보해요."),
+    IMPROVE_ENVIRONMENT(FeedbackType.FAILURE, "주변 환경을 개선해요."),
+    ;
+
+    private final FeedbackType type;
+    private final String indicator;
+
+    public static FeedbackIndicator of(String indicator) {
+        return Arrays.stream(FeedbackIndicator.values())
+            .filter(feedbackIndicator -> feedbackIndicator.getIndicator().equals(indicator))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Invalid feedback indicator: " + indicator));
+    }
+}

--- a/src/main/java/ac/dnd/dodal/domain/feedback/enums/FeedbackQuestion.java
+++ b/src/main/java/ac/dnd/dodal/domain/feedback/enums/FeedbackQuestion.java
@@ -1,0 +1,15 @@
+package ac.dnd.dodal.domain.feedback.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FeedbackQuestion {
+
+    SUCCESS_PLAN_QUESTION("조금 더 수월하게 달성하기 위해 무엇을 바꿔볼까요?"),
+    FAILURE_PLAN_QUESTION("조금 더 수월하게 달성하기 위해 무엇을 바꿔볼까요?"),
+    ;
+
+    private final String question;    
+}

--- a/src/main/java/ac/dnd/dodal/domain/guide/enums/UpdatePlanGuide.java
+++ b/src/main/java/ac/dnd/dodal/domain/guide/enums/UpdatePlanGuide.java
@@ -5,134 +5,137 @@ import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import ac.dnd.dodal.domain.feedback.enums.FeedbackIndicator;
+
 @Getter
 @RequiredArgsConstructor
 public enum UpdatePlanGuide {
 
     // SUCCESS
     REORGANIZE_PRIORITIES("가장 중요한 목표부터 다시 정리해볼까요?",
-        UserType.GOAL_ORIENTED, "우선 순위를 재조정해요."),
+        UserType.GOAL_ORIENTED, FeedbackIndicator.REORGANIZE_PRIORITIES),
     SIMPLIFY_CORE_STEPS("핵심 단계만 남기고 단순화해보세요.",
-        UserType.GOAL_ORIENTED, "시간 단축을 시도해볼래요."),
+        UserType.GOAL_ORIENTED, FeedbackIndicator.TRY_TIME_SAVING),
     ALIGN_GOAL_AND_PLAN("목표와 계획이 잘 맞는지 살펴보세요.",
-        UserType.GOAL_ORIENTED, "계획 정확도를 점검해요."),
+        UserType.GOAL_ORIENTED, FeedbackIndicator.CHECK_PLAN_ACCURACY),
     REVIEW_PROGRESS("현재까지의 진행 상태를 점검해보세요.",
-        UserType.GOAL_ORIENTED, "진행 상황을 더 꼼꼼히 확인해요."),
+        UserType.GOAL_ORIENTED, FeedbackIndicator.CHECK_PROGRESS),
     LEARN_FROM_PAST("지금까지의 방식에서 배울 점을 찾아보세요.", 
-        UserType.GOAL_ORIENTED, "스스로 패턴을 분석해봐요."),
+        UserType.GOAL_ORIENTED, FeedbackIndicator.ANALYZE_PATTERN),
 
     ADJUST_PRIORITIES("지금 상황에 맞게 우선 순위를 조정해볼까요?",
-        UserType.FLEXIBLE_EXECUTION, "우선 순위를 재조정해요."),
+        UserType.FLEXIBLE_EXECUTION, FeedbackIndicator.REORGANIZE_PRIORITIES),
     TRY_TIME_SAVING_METHODS("시간을 줄일 방법을 가볍게 시도해보세요.",
-        UserType.FLEXIBLE_EXECUTION, "시간 단축을 시도해볼래요."),
+        UserType.FLEXIBLE_EXECUTION, FeedbackIndicator.TRY_TIME_SAVING),
     ADJUST_WHILE_EXECUTING("계획보다는 실행하면서 조정해보세요.",
-        UserType.FLEXIBLE_EXECUTION, "계획 실행 시간을 좀 더 확보해요."),
+        UserType.FLEXIBLE_EXECUTION, FeedbackIndicator.CHECK_PLAN_ACCURACY),
     MODIFY_DURING_PROCESS("진행하면서 필요한 조정을 해보세요.",
-        UserType.FLEXIBLE_EXECUTION, "진행 상황을 더 꼼꼼히 확인해요."),
+        UserType.FLEXIBLE_EXECUTION, FeedbackIndicator.CHECK_PROGRESS),
     IDENTIFY_EFFECTIVE_TIME("내가 가장 효과적으로 움직일 때를 생각해보세요.",
-        UserType.FLEXIBLE_EXECUTION, "스스로 패턴을 분석해봐요."),
+        UserType.FLEXIBLE_EXECUTION, FeedbackIndicator.ANALYZE_PATTERN),
 
     REORGANIZE_CHECKLIST("체크리스트를 다시 정리해볼까요?",
-        UserType.CHECKLIST_BASED, "우선 순위를 재조정해요."),
+        UserType.CHECKLIST_BASED, FeedbackIndicator.REORGANIZE_PRIORITIES),
     REMOVE_UNNECESSARY_STEPS("불필요한 단계를 줄여볼까요?",
-        UserType.CHECKLIST_BASED, "시간 단축을 시도해볼래요."),
+        UserType.CHECKLIST_BASED, FeedbackIndicator.TRY_TIME_SAVING),
     FINE_TUNE_PLAN("계획을 더 세밀하게 조정해볼까요?",
-        UserType.CHECKLIST_BASED, "계획 정확도를 점검해요."),
+        UserType.CHECKLIST_BASED, FeedbackIndicator.CHECK_PLAN_ACCURACY),
     TRACK_PROGRESS_WITH_CHECKLIST("체크리스트를 보며 진행 상황을 확인해보세요.",
-        UserType.CHECKLIST_BASED, "진행 상황을 더 꼼꼼히 확인해요."),
+        UserType.CHECKLIST_BASED, FeedbackIndicator.CHECK_PROGRESS),
     DISCOVER_PATTERN_THROUGH_RECORDS("기록을 통해 나만의 패턴을 찾아보세요.",
-        UserType.CHECKLIST_BASED, "스스로 패턴을 분석해봐요."),
+        UserType.CHECKLIST_BASED, FeedbackIndicator.ANALYZE_PATTERN),
 
     RECONSIDER_MAIN_GOALS("중요한 목표부터 다시 생각해볼까요?",
-        UserType.PREFERRING_A_BIG_DIRECTION, "우선 순위를 재조정해요."),
+        UserType.PREFERRING_A_BIG_DIRECTION, FeedbackIndicator.REORGANIZE_PRIORITIES),
     BALANCE_BIG_PICTURE_AND_TIME("큰 그림을 유지하며 시간을 조정해보세요.",
-        UserType.PREFERRING_A_BIG_DIRECTION, "시간 단축을 시도해볼래요."),
+        UserType.PREFERRING_A_BIG_DIRECTION, FeedbackIndicator.TRY_TIME_SAVING),
     VERIFY_GOAL_ALIGNMENT("목표와 맞는 계획인지 다시 확인해보세요.",
-        UserType.PREFERRING_A_BIG_DIRECTION, "계획 정확도를 점검해요."),
+        UserType.PREFERRING_A_BIG_DIRECTION, FeedbackIndicator.CHECK_PLAN_ACCURACY),
     CHECK_CURRENT_POSITION("목표를 떠올리며 현재 위치를 점검해보세요.",
-        UserType.PREFERRING_A_BIG_DIRECTION, "진행 상황을 더 꼼꼼히 확인해요."),
+        UserType.PREFERRING_A_BIG_DIRECTION, FeedbackIndicator.CHECK_PROGRESS),
     ANALYZE_PATTERNS_IN_FLOW("큰 흐름 속에서 나의 패턴을 살펴보세요.",
-        UserType.PREFERRING_A_BIG_DIRECTION, "스스로 패턴을 분석해봐요."),
+        UserType.PREFERRING_A_BIG_DIRECTION, FeedbackIndicator.ANALYZE_PATTERN),
 
     START_WITH_EASY_TASKS_SUCCESS("쉬운 것부터 시작해볼까요?",
-        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, "우선 순위를 재조정해요."),
+        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, FeedbackIndicator.REORGANIZE_PRIORITIES),
     QUICKLY_COMPLETE_SMALL_GOALS("작은 목표부터 빠르게 해보세요.",
-        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, "시간 단축을 시도해볼래요."),
+        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, FeedbackIndicator.TRY_TIME_SAVING),
     ADJUST_FOR_MANAGEABILITY("너무 어렵지 않게 계획을 조정해보세요.",
-        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, "계획 실행 시간을 좀 더 확보해요."),
+        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, FeedbackIndicator.CHECK_PLAN_ACCURACY),
     MOTIVATE_THROUGH_SMALL_SUCCESS("조금씩 해낸 걸 확인하며 동기를 얻어보세요.",
-        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, "진행 상황을 더 꼼꼼히 확인해요."),
+        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, FeedbackIndicator.CHECK_PROGRESS),
     FIND_COMFORTABLE_START_METHOD("내가 편하게 시작할 수 있는 방법을 찾아보세요.",
-        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, "스스로 패턴을 분석해봐요."),
+        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, FeedbackIndicator.ANALYZE_PATTERN),
 
     // FAILURE
     SIMPLIFY_STEPS("단계를 줄여 더 간단하게 시작해볼까요?",
-        UserType.GOAL_ORIENTED, "계획을 더 쉽게 설정해요."),
+        UserType.GOAL_ORIENTED, FeedbackIndicator.SIMPLIFY_STEPS),
     BREAK_DOWN_GOALS("목표를 더 구체적인 단계로 나눠볼까요?",
-        UserType.GOAL_ORIENTED, "구체적인 계획을 설정해요."),
+        UserType.GOAL_ORIENTED, FeedbackIndicator.SPECIFY_PLAN),
     CHECK_PROGRESS_PERIODICALLY("중간중간 진행을 체크해보세요.",
-        UserType.GOAL_ORIENTED, "진행상황을 수시로 확인해요."),
+        UserType.GOAL_ORIENTED, FeedbackIndicator.CHECK_PROGRESS_REGULARLY),
     ALLOCATE_TIME_FOR_IMPORTANT_GOALS("중요한 목표를 위해 시간을 먼저 확보해보세요.",
-        UserType.GOAL_ORIENTED, "계획 실행 시간을 좀 더 확보해요."),
+        UserType.GOAL_ORIENTED, FeedbackIndicator.ALLOCATE_MORE_TIME),
     CREATE_FOCUSED_ENVIRONMENT("더 집중할 수 있는 환경을 만들어볼까요?",
-        UserType.GOAL_ORIENTED, "주변 환경을 개선해요."),
+        UserType.GOAL_ORIENTED, FeedbackIndicator.IMPROVE_ENVIRONMENT),
 
     START_WITH_EASY_TASKS_FAILURE("먼저 할 수 있는 쉬운 것부터 해볼까요?",
-        UserType.FLEXIBLE_EXECUTION, "계획을 더 쉽게 설정해요."),
+        UserType.FLEXIBLE_EXECUTION, FeedbackIndicator.SIMPLIFY_STEPS),
     PLAN_SIMPLY("너무 복잡하지 않게 가볍게 계획해보세요.",
-        UserType.FLEXIBLE_EXECUTION, "구체적인 계획을 설정해요."),
+        UserType.FLEXIBLE_EXECUTION, FeedbackIndicator.SPECIFY_PLAN),
     ADJUST_DURING_PROGRESS("진행하면서 필요한 조정을 해보세요.",
-        UserType.FLEXIBLE_EXECUTION, "진행 상황을 수시로 확인해요."),
+        UserType.FLEXIBLE_EXECUTION, FeedbackIndicator.CHECK_PROGRESS_REGULARLY),
     FIND_OPTIMAL_EXECUTION_TIME("실행이 편한 시간대를 찾아보세요.",
-        UserType.FLEXIBLE_EXECUTION, "계획 실행 시간을 좀 더 확보해요."),
+        UserType.FLEXIBLE_EXECUTION, FeedbackIndicator.ALLOCATE_MORE_TIME),
     CREATE_COMFORTABLE_ENVIRONMENT("내가 편하게 몰입할 수 있는 환경을 만들어보세요.",
-        UserType.FLEXIBLE_EXECUTION, "주변 환경을 개선해요."),
+        UserType.FLEXIBLE_EXECUTION, FeedbackIndicator.IMPROVE_ENVIRONMENT),
 
     SIMPLIFY_CHECKLIST("체크리스트를 더 단순하게 만들어볼까요?",
-        UserType.CHECKLIST_BASED, "계획을 더 쉽게 설정해요."),
+        UserType.CHECKLIST_BASED, FeedbackIndicator.SIMPLIFY_STEPS),
     DETAIL_SUBSTEPS("세부 단계를 더 구체적으로 정리해볼까요?",
-        UserType.CHECKLIST_BASED, "구체적인 계획을 설정해요."),
+        UserType.CHECKLIST_BASED, FeedbackIndicator.SPECIFY_PLAN),
     TRACK_PROGRESS_WITH_LIST("리스트를 보며 진행 상태를 점검해보세요.",
-        UserType.CHECKLIST_BASED, "진행 상황을 더 꼼꼼히 확인해요."),
+        UserType.CHECKLIST_BASED, FeedbackIndicator.CHECK_PROGRESS),
     RESERVE_TIME_IN_SCHEDULE("일정에 맞춰 시간을 미리 확보해보세요.",
-        UserType.CHECKLIST_BASED, "계획 실행 시간을 좀 더 확보해요."),
+        UserType.CHECKLIST_BASED, FeedbackIndicator.ALLOCATE_MORE_TIME),
     WORK_IN_ORGANIZED_SPACE("정리된 공간에서 더 효율적으로 진행해보세요.",
-        UserType.CHECKLIST_BASED, "주변 환경을 개선해요."),
+        UserType.CHECKLIST_BASED, FeedbackIndicator.IMPROVE_ENVIRONMENT),
 
     OUTLINE_MAIN_FLOW("큰 흐름만 정리하고 시작해볼까요?",
-        UserType.PREFERRING_A_BIG_DIRECTION, "계획을 더 쉽게 설정해요."),
+        UserType.PREFERRING_A_BIG_DIRECTION, FeedbackIndicator.SIMPLIFY_STEPS),
     REFINE_GOALS("목표를 더 구체적인 방향으로 정리해볼까요?",
-        UserType.PREFERRING_A_BIG_DIRECTION, "구체적인 계획을 설정해요."),
+        UserType.PREFERRING_A_BIG_DIRECTION, FeedbackIndicator.SPECIFY_PLAN),
     CHECK_DIRECTION_OCCASIONALLY("방향이 맞는지 가끔 점검해보세요.",
-        UserType.PREFERRING_A_BIG_DIRECTION, "진행 상황을 수시로 확인해요."),
+        UserType.PREFERRING_A_BIG_DIRECTION, FeedbackIndicator.CHECK_PROGRESS_REGULARLY),
     ADJUST_TIME_FOR_GOALS("목표를 위해 시간을 어떻게 조정할지 고민해보세요.",
-        UserType.PREFERRING_A_BIG_DIRECTION, "계획 실행 시간을 좀 더 확보해요."),
+        UserType.PREFERRING_A_BIG_DIRECTION, FeedbackIndicator.ALLOCATE_MORE_TIME),
     CREATE_INSPIRING_ENVIRONMENT("나에게 영감을 주는 환경을 만들어볼까요?",
-        UserType.PREFERRING_A_BIG_DIRECTION, "주변 환경을 개선해요."),
+        UserType.PREFERRING_A_BIG_DIRECTION, FeedbackIndicator.IMPROVE_ENVIRONMENT),
 
     START_EASILY("너무 어렵지 않게 쉽게 시작해볼까요?",
-        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, "계획을 더 쉽게 설정해요."),
+        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, FeedbackIndicator.SIMPLIFY_STEPS),
     SET_SMALL_ACHIEVABLE_GOALS("실천하기 편한 작은 목표부터 정해볼까요?",
-        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, "구체적인 계획을 설정해요."),
+        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, FeedbackIndicator.SPECIFY_PLAN),
     RECORD_SMALL_SUCCESSES("작은 성취를 기록하며 동기를 만들어보세요.",
-        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, "진행 상황을 수시로 확인해요."),
+        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, FeedbackIndicator.CHECK_PROGRESS_REGULARLY),
     SCHEDULE_EXECUTION_TIME("실행할 시간을 미리 정해두면 도움이 될 거예요.",
-        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, "계획 실행 시간을 좀 더 확보해요."),
+        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, FeedbackIndicator.ALLOCATE_MORE_TIME),
     MAKE_STARTING_EASIER("더 편하게 시작할 수 있는 환경을 만들어보세요.",
-        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, "주변 환경을 개선해요.");
+        UserType.LACK_OF_MOTIVATION_TO_EXECUTE, FeedbackIndicator.IMPROVE_ENVIRONMENT),
     ;
 
     private final String guide;
     private final UserType userType;
-    private final String feedbackIndicator;
+    private final FeedbackIndicator feedbackIndicator;
 
     public static UpdatePlanGuide getByUserTypeAndFeedbackIndicator
         (String userType, String feedbackIndicator) {
         UserType userTypeEnum = UserType.valueOf(userType);
+        FeedbackIndicator feedbackIndicatorEnum = FeedbackIndicator.of(feedbackIndicator);
 
         return Arrays.stream(UpdatePlanGuide.values())
             .filter(guide -> guide.getUserType().equals(userTypeEnum) 
-                && guide.getFeedbackIndicator().equals(feedbackIndicator))
+                && guide.getFeedbackIndicator().equals(feedbackIndicatorEnum))
             .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException(
                 "Invalid user type or feedback indicator: " + userType + ", " + feedbackIndicator));

--- a/src/main/java/ac/dnd/dodal/domain/guide/util/GuidianceGenerator.java
+++ b/src/main/java/ac/dnd/dodal/domain/guide/util/GuidianceGenerator.java
@@ -19,16 +19,17 @@ public class GuidianceGenerator {
         AnswerContent difficultySetPlan = getDifficultySetPlan(userAnswers);
 
         try {
-            UserType userType = UserType.getByPreferenceAndDifficultySetPlan(
-                    preferenceSetPlan, difficultySetPlan);
+            UserType userType = UserType.getByPreferenceAndDifficultySetPlan(preferenceSetPlan,
+                    difficultySetPlan);
 
             return userType.getValue();
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
             throw new InternalServerErrorException(
-                UserGuideExceptionCode.FAIL_TO_GENERATE_USER_GUIDE, e);
+                    UserGuideExceptionCode.FAIL_TO_GENERATE_USER_GUIDE, e);
         }
     }
+
     public static String generateNewGoalGuide(List<UserAnswer> userAnswers) {
         AnswerContent interestGoal = getInterestGoal(userAnswers);
 

--- a/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
+++ b/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
@@ -31,7 +31,7 @@ public class PlanController {
     private final DeletePlanUseCase deletePlanUseCase;
 
     @PostMapping("/{planId}/complete")
-    public ApiResponse<?> completePlan(
+    public ApiResponse<PlanElement> completePlan(
         @UserId Long userId,
         @PathVariable Long planId,
         @RequestParam String status,

--- a/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
+++ b/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
@@ -1,5 +1,7 @@
 package ac.dnd.dodal.ui.plan;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import ac.dnd.dodal.common.annotation.UserId;
 import ac.dnd.dodal.common.response.ApiResponse;
@@ -16,7 +19,9 @@ import ac.dnd.dodal.domain.plan.model.Plan;
 import ac.dnd.dodal.domain.plan.enums.PlanStatus;
 import ac.dnd.dodal.application.plan.usecase.CompletePlanUseCase;
 import ac.dnd.dodal.application.plan.usecase.DeletePlanUseCase;
+import ac.dnd.dodal.application.plan.usecase.GetPlanUseCase;
 import ac.dnd.dodal.application.plan.dto.command.DeletePlanCommand;
+import ac.dnd.dodal.application.plan.dto.query.GetPlanQuery;
 import ac.dnd.dodal.ui.feedback.request.CreateFeedbackRequest;
 import ac.dnd.dodal.ui.plan.response.PlanElement;
 
@@ -29,6 +34,7 @@ public class PlanController {
 
     private final CompletePlanUseCase completePlanUseCase;
     private final DeletePlanUseCase deletePlanUseCase;
+    private final GetPlanUseCase getPlanUseCase;
 
     @PostMapping("/{planId}/complete")
     public ApiResponse<PlanElement> completePlan(
@@ -37,9 +43,18 @@ public class PlanController {
         @RequestParam String status,
         @RequestBody CreateFeedbackRequest request
     ) {
-        List<PlanElement> plans = completePlanUseCase.completePlan(request.toCommand(userId, planId, PlanStatus.of(status)));
+        Plan plan = completePlanUseCase
+                .completePlan(request.toCommand(userId, planId, PlanStatus.of(status)));
 
         return ApiResponse.success(plans);
+    }
+
+    @GetMapping("/{planId}/history")
+    public ApiResponse<List<PlanElement>> getPlanHistory(
+        @UserId Long userId,
+        @PathVariable Long planId
+    ) {
+        return ApiResponse.success(getPlanUseCase.getPlanHistory(new GetPlanQuery(userId, planId)));
     }
 
     @DeleteMapping("/{planId}")

--- a/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
+++ b/src/main/java/ac/dnd/dodal/ui/plan/PlanController.java
@@ -25,8 +25,6 @@ import ac.dnd.dodal.application.plan.dto.query.GetPlanQuery;
 import ac.dnd.dodal.ui.feedback.request.CreateFeedbackRequest;
 import ac.dnd.dodal.ui.plan.response.PlanElement;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/plans")
 @RequiredArgsConstructor
@@ -46,7 +44,7 @@ public class PlanController {
         Plan plan = completePlanUseCase
                 .completePlan(request.toCommand(userId, planId, PlanStatus.of(status)));
 
-        return ApiResponse.success(plans);
+        return ApiResponse.success(PlanElement.of(plan));
     }
 
     @GetMapping("/{planId}/history")

--- a/src/test/java/ac/dnd/dodal/acceptance/plan/GetPlanAcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan/GetPlanAcceptanceTest.java
@@ -1,0 +1,38 @@
+package ac.dnd.dodal.acceptance.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import io.restassured.response.Response;
+import io.restassured.common.mapper.TypeRef;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import ac.dnd.dodal.AcceptanceTest;
+import ac.dnd.dodal.common.enums.CommonResultCode;
+import ac.dnd.dodal.ui.plan.response.PlanElement;
+import ac.dnd.dodal.acceptance.plan.steps.PlanSteps;
+import ac.dnd.dodal.common.response.ApiResponse;
+
+public class GetPlanAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    public void get_plan_history_success() {
+        Response response = PlanSteps.getPlan(6L, authorizationHeader);
+        ApiResponse<List<PlanElement>> apiResponse = response.as(new TypeRef<ApiResponse<List<PlanElement>>>() {});
+
+        log.info("apiResponse: {}", apiResponse);
+        // 200
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        // COM001
+        assertThat(apiResponse.code()).isEqualTo(CommonResultCode.SUCCESS.getCode());
+        // Success
+        assertThat(apiResponse.message()).isEqualTo(CommonResultCode.SUCCESS.getMessage());
+        // size is greater than 0
+        assertThat(apiResponse.data().size()).isGreaterThan(0);
+        // PlanElement
+        assertThat(apiResponse.data().get(0)).isInstanceOf(PlanElement.class);
+    }
+}

--- a/src/test/java/ac/dnd/dodal/acceptance/plan/PlanCompleteAcceptanceTest.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan/PlanCompleteAcceptanceTest.java
@@ -41,8 +41,8 @@ public class PlanCompleteAcceptanceTest extends AcceptanceTest {
         Response response =
                 PlanSteps.completePlan(uncompletedPlanId, SUCCESS_STATUS, header, feedbackRequest);
       
-        ApiResponse<List<PlanElement>> apiResponse =
-                response.as(new TypeRef<ApiResponse<List<PlanElement>>>() {});
+        ApiResponse<PlanElement> apiResponse =
+                response.as(new TypeRef<ApiResponse<PlanElement>>() {});
 
         log.info("response = {}", response.asString());
         // then 200
@@ -64,8 +64,8 @@ public class PlanCompleteAcceptanceTest extends AcceptanceTest {
         Response response =
                 PlanSteps.completePlan(uncompletedPlanId2, FAILURE_STATUS, header, feedbackRequest);
 
-      ApiResponse<List<PlanElement>> apiResponse =
-                response.as(new TypeRef<ApiResponse<List<PlanElement>>>() {});
+        ApiResponse<PlanElement> apiResponse =
+                response.as(new TypeRef<ApiResponse<PlanElement>>() {});
 
         log.info("response = {}", response.asString());
         // then 200

--- a/src/test/java/ac/dnd/dodal/acceptance/plan/steps/PlanSteps.java
+++ b/src/test/java/ac/dnd/dodal/acceptance/plan/steps/PlanSteps.java
@@ -14,6 +14,7 @@ public class PlanSteps {
     private static final String BASE_URL = "/api/plans";
     private static final String COMPLETE_PLAN_URL = BASE_URL + "/{planId}/complete?status={status}";
     private static final String DELETE_PLAN_URL = BASE_URL + "/{planId}";
+    private static final String GET_PLAN_HISTORY_URL = BASE_URL + "/{planId}/history";
 
     public static Response completePlan(Long planId, String status,
             Map<String, Object> header, CreateFeedbackRequest request) {
@@ -27,6 +28,20 @@ public class PlanSteps {
                 .body(request)
             .when()
                 .post(url)
+            .then().log().all()
+                .extract()
+                .response();
+    }
+
+    public static Response getPlan(Long planId, Map<String, Object> header) {
+        String url = GET_PLAN_HISTORY_URL
+            .replace("{planId}", planId.toString());
+
+        return given().log().all()
+                .contentType(ContentType.JSON)
+                .headers(header)
+            .when()
+                .get(url)
             .then().log().all()
                 .extract()
                 .response();

--- a/src/test/java/ac/dnd/dodal/application/plan/dto/CompletePlanCommandFixture.java
+++ b/src/test/java/ac/dnd/dodal/application/plan/dto/CompletePlanCommandFixture.java
@@ -1,14 +1,16 @@
 package ac.dnd.dodal.application.plan.dto;
 
 import ac.dnd.dodal.domain.plan.enums.PlanStatus;
+import ac.dnd.dodal.domain.feedback.enums.FeedbackQuestion;
+import ac.dnd.dodal.domain.feedback.enums.FeedbackIndicator;
 import ac.dnd.dodal.application.plan.dto.command.CompletePlanCommand;
 
 public class CompletePlanCommandFixture {
 
     private static final Long userId = 1L;
     private static final Long planId = 1L;
-    private static final String question = "조금 더 수월하게 달성하기 위해 무엇을 바꿔볼까요?";
-    private static final String indicator = "우선순위를 재조정해요.";
+    private static final String question = FeedbackQuestion.SUCCESS_PLAN_QUESTION.getQuestion();
+    private static final String indicator = FeedbackIndicator.REORGANIZE_PRIORITIES.getIndicator();
 
     public static CompletePlanCommand completePlanCommand() {
         return new CompletePlanCommand(userId, planId, PlanStatus.SUCCESS, question, indicator);

--- a/src/test/java/ac/dnd/dodal/application/plan/service/PlanCommandServiceTest.java
+++ b/src/test/java/ac/dnd/dodal/application/plan/service/PlanCommandServiceTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Optional;
 
-import ac.dnd.dodal.ui.plan.response.PlanElement;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -236,13 +235,13 @@ public class PlanCommandServiceTest {
             .thenReturn(userType);
 
         // when
-        List<PlanElement> savedPlan = planCommandService.completePlan(command);
+        Plan savedPlan = planCommandService.completePlan(command);
 
         // then
         verify(planFeedbackService).saveAll(anyList());
         verify(planService).save(any(Plan.class));
         verify(eventPublisher).publishEvent(any(PlanCompletedEvent.class));
-        assertThat(savedPlan.getLast().status()).isEqualTo(PlanStatus.SUCCESS);
+        assertThat(savedPlan.getStatus()).isEqualTo(PlanStatus.SUCCESS);
     }
 
     @DisplayName("Complete failure plan success")
@@ -259,13 +258,13 @@ public class PlanCommandServiceTest {
             .thenReturn(userType);
 
         // when
-        List<PlanElement> savedPlan = planCommandService.completePlan(command);
+        Plan savedPlan = planCommandService.completePlan(command);
 
         // then
         verify(planFeedbackService).saveAll(anyList());
         verify(planService).save(any(Plan.class));
         verify(eventPublisher).publishEvent(any(PlanCompletedEvent.class));
-        assertThat(savedPlan.getLast().status()).isEqualTo(PlanStatus.FAILURE);
+        assertThat(savedPlan.getStatus()).isEqualTo(PlanStatus.FAILURE);
     }
     
     @DisplayName("Complete failure plan failure by achieved goal")

--- a/src/test/java/ac/dnd/dodal/ui/feedback/fixture/FeedbackUIFixture.java
+++ b/src/test/java/ac/dnd/dodal/ui/feedback/fixture/FeedbackUIFixture.java
@@ -1,10 +1,15 @@
 package ac.dnd.dodal.ui.feedback.fixture;
 
+import ac.dnd.dodal.domain.feedback.enums.FeedbackIndicator;
+import ac.dnd.dodal.domain.feedback.enums.FeedbackQuestion;
 import ac.dnd.dodal.ui.feedback.request.CreateFeedbackRequest;
 
 public class FeedbackUIFixture {
 
+    private static final String question = FeedbackQuestion.SUCCESS_PLAN_QUESTION.getQuestion();
+    private static final String indicator = FeedbackIndicator.REORGANIZE_PRIORITIES.getIndicator();
+
     public static CreateFeedbackRequest createFeedbackRequest() {
-        return new CreateFeedbackRequest("조금 더 수월하게 달성하기 위해 뭘 해야할까요?", "우선순위를 재조정해요.");
+        return new CreateFeedbackRequest(question, indicator);
     }
 }


### PR DESCRIPTION
리뷰 전 전달사항
1. fork repo에 올렸어야했는데... 다음부터 유의하겠습니다
2. complete하고 나서 한번만 보여지는 게 아니라 상세 페이지로 매번 조회가 되야해서 complete 시 반환과 조회를 분리해놨어요.
3. 리뷰 요청이 없길래 구현을 안하신 줄 알았는데 이미 머지가 되어있어서 약간 당황했습니다🥲 앞으로 싱크를 잘 맞춰봐요

로직 설명
- complete 시에는 feedback이 반영된 plan 하나만 반환합니다
- api/plan/{planId}/hisotry를 통해서 가장 completedDate가 가까운 플랜 3개 (본인 포함)를 반환합니다.
