### PR TITLE
[FIX] 탈퇴 후 재가입 시 온보딩이 이루어지지 않던 오류 수정  

### DIFF
--- a/src/main/java/ac/dnd/dodal/application/plan_history/repository/PlanHistoryRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/plan_history/repository/PlanHistoryRepository.java
@@ -43,4 +43,7 @@ public interface PlanHistoryRepository extends JpaRepository<PlanHistory, Long> 
     @Query("SELECT ph FROM plan_histories ph WHERE ph.goal.goalId = :goalId"
             + " AND ph.deletedAt IS NULL")
     List<PlanHistory> findAllByGoalId(Long goalId);
+
+    @Query("SELECT ph FROM plan_histories ph WHERE ph.goal.goalId = :goalId")
+    List<PlanHistory> findAllByGoalIdWithDeleted(Long goalId);
 }

--- a/src/main/java/ac/dnd/dodal/application/user/repository/UserAnswerRepository.java
+++ b/src/main/java/ac/dnd/dodal/application/user/repository/UserAnswerRepository.java
@@ -12,4 +12,7 @@ public interface UserAnswerRepository extends JpaRepository<UserAnswer, Long> {
 
     @Query("SELECT ua FROM UserAnswer ua WHERE ua.user = :user AND ua.deletedAt IS NULL")
     List<UserAnswer> findAllByUser(User user);
+
+    @Query("SELECT ua FROM UserAnswer ua WHERE ua.user = :user")
+    List<UserAnswer> findAllByUserWithDeleted(User user);
 }

--- a/src/main/java/ac/dnd/dodal/application/user/service/UserCommandService.java
+++ b/src/main/java/ac/dnd/dodal/application/user/service/UserCommandService.java
@@ -150,9 +150,9 @@ public class UserCommandService implements UserCommandUseCase, CreateUserAnswerU
 
   public void deleteUserInfo(User user) {
     // 회원탈퇴 성공 시 User의 deletedAt을 현재 시간으로 업데이트하여 soft delete 처리
-    user.withdrawUser();
-
     deleteAllUserAnswerOf(user);
+
+    user.withdrawUser();
 
     // TODO: 관련 데이터 비동기 삭제 로직 추가
     eventPublisher.publishEvent(new UserWithdrawnEvent(user.getId()));

--- a/src/main/java/ac/dnd/dodal/domain/plan_feedback/model/PlanFeedback.java
+++ b/src/main/java/ac/dnd/dodal/domain/plan_feedback/model/PlanFeedback.java
@@ -43,16 +43,13 @@ public class PlanFeedback extends BaseEntity {
     }
 
     public PlanFeedback(String question, String indicator) {
-        this(null, question, indicator, null, null, null);
+        this(null, question, indicator);
     }
 
-    public PlanFeedback(Plan plan, String question, String indicator, LocalDateTime createdAt,
-            LocalDateTime updatedAt, LocalDateTime deletedAt) {
+    public PlanFeedback(Plan plan, String question, String indicator) {
+        super();
         this.plan = plan;
         this.question = question;
         this.indicator = indicator;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.deletedAt = deletedAt;
     }
 }

--- a/src/test/java/ac/dnd/dodal/IntegrationTest.java
+++ b/src/test/java/ac/dnd/dodal/IntegrationTest.java
@@ -1,9 +1,11 @@
 package ac.dnd.dodal;
 
+import ac.dnd.dodal.config.AsyncConfigTest;
 import jakarta.transaction.Transactional;
 
 import org.jasypt.encryption.StringEncryptor;
 
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,6 +27,7 @@ import ac.dnd.dodal.application.plan.repository.PlanRepository;
 @Transactional
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(AsyncConfigTest.class)
 public abstract class IntegrationTest {
 
     @Autowired

--- a/src/test/java/ac/dnd/dodal/application/goal/service/GoalEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/goal/service/GoalEventListenerTest.java
@@ -2,6 +2,7 @@ package ac.dnd.dodal.application.goal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ac.dnd.dodal.IntegrationTest;
 import ac.dnd.dodal.application.goal.repository.GoalRepository;
 import ac.dnd.dodal.application.user.dto.UserCommandFixture;
 import ac.dnd.dodal.application.user.service.UserCommandService;
@@ -9,19 +10,13 @@ import ac.dnd.dodal.domain.goal.model.Goal;
 import ac.dnd.dodal.domain.user.event.UserWithdrawnEvent;
 import ac.dnd.dodal.domain.user.model.User;
 import ac.dnd.dodal.ui.auth.request.OAuthUserInfoRequestDto;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@Transactional
-public class GoalEventListenerTest {
+public class GoalEventListenerTest extends IntegrationTest {
 
     @Autowired
     private ApplicationEventPublisher eventPublisher;

--- a/src/test/java/ac/dnd/dodal/application/goal/service/GoalStatisticsEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/goal/service/GoalStatisticsEventListenerTest.java
@@ -57,7 +57,7 @@ public class GoalStatisticsEventListenerTest extends IntegrationTest {
         Plan plan = PlanFixture.successPlan();
         Long goalId = plan.getGoal().getGoalId();
         PlanFeedback feedback = new PlanFeedback(
-                plan, "question", "indicator", null, null, null);
+                plan, "question", "indicator");
         GoalStatistics previousGoalStatistics = goalStatisticsService.findByIdOrThrow(goalId);
         int previousSuccessCount = previousGoalStatistics.getSuccessCount();
         int previousFailureCount = previousGoalStatistics.getFailureCount();

--- a/src/test/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/plan_feedback/service/PlanFeedbackEventListenerTest.java
@@ -7,6 +7,8 @@ import ac.dnd.dodal.domain.plan.model.Plan;
 import ac.dnd.dodal.domain.plan_feedback.model.PlanFeedback;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -16,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class PlanFeedbackEventListenerTest extends IntegrationTest {
 
+    private static final Logger log = LoggerFactory.getLogger(PlanFeedbackEventListenerTest.class);
     @Autowired
     private ApplicationEventPublisher eventPublisher;
 
@@ -28,7 +31,8 @@ public class PlanFeedbackEventListenerTest extends IntegrationTest {
         // given
         Plan plan = PlanFixture.plan();
         List<PlanFeedback> planFeedbacks = planFeedbackService.findAllByPlanId(plan.getPlanId());
-        assertThat(planFeedbacks).isNotEmpty();
+        assertThat(planFeedbacks).hasSize(3);
+        assertThat(planFeedbacks.getFirst().getCreatedAt()).isNotNull();
         assertThat(planFeedbacks.getFirst().getDeletedAt()).isNull();
         assertThat(planFeedbacks.getLast().getDeletedAt()).isNull();
         // when

--- a/src/test/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventListenerTest.java
+++ b/src/test/java/ac/dnd/dodal/application/plan_history/service/PlanHistoryEventListenerTest.java
@@ -41,7 +41,7 @@ public class PlanHistoryEventListenerTest extends IntegrationTest {
         }
 
         // then
-        assertThat(planHistoryRepository.findAllByGoalId(goalId).getFirst().getDeletedAt()).isNotNull();
-        assertThat(planHistoryRepository.findAllByGoalId(goalId).getLast().getDeletedAt()).isNotNull();
+        assertThat(planHistoryRepository.findAllByGoalIdWithDeleted(goalId).getFirst().getDeletedAt()).isNotNull();
+        assertThat(planHistoryRepository.findAllByGoalIdWithDeleted(goalId).getLast().getDeletedAt()).isNotNull();
     }
 }

--- a/src/test/java/ac/dnd/dodal/application/user/service/UserCommandServiceTest.java
+++ b/src/test/java/ac/dnd/dodal/application/user/service/UserCommandServiceTest.java
@@ -103,7 +103,8 @@ public class UserCommandServiceTest {
                 Thread.currentThread().interrupt();
         }
 
-        List<UserAnswer> deletedUserAnswers = userAnswerRepository.findAllByUser(user);
-        assertThat(deletedUserAnswers).isEmpty();
+        List<UserAnswer> deletedUserAnswers = userAnswerRepository.findAllByUserWithDeleted(user);
+        assertThat(deletedUserAnswers.getFirst().getDeletedAt()).isNotNull();
+        assertThat(deletedUserAnswers.getLast().getDeletedAt()).isNotNull();
     }
 }

--- a/src/test/java/ac/dnd/dodal/config/AsyncConfigTest.java
+++ b/src/test/java/ac/dnd/dodal/config/AsyncConfigTest.java
@@ -1,0 +1,18 @@
+package ac.dnd.dodal.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+import java.util.concurrent.Executor;
+
+@TestConfiguration
+@EnableAsync
+public class AsyncConfigTest implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        return new SyncTaskExecutor(); // 동기 실행
+    }
+}

--- a/src/test/java/ac/dnd/dodal/domain/feedback/PlanFeedbackFixture.java
+++ b/src/test/java/ac/dnd/dodal/domain/feedback/PlanFeedbackFixture.java
@@ -10,12 +10,10 @@ public class PlanFeedbackFixture {
     private static final Plan PLAN = PlanFixture.plan();
 
     public static PlanFeedback planFeedback() {
-        return new PlanFeedback(PLAN, "question", "indicator",
-                LocalDateTime.now(), LocalDateTime.now(), null);
+        return new PlanFeedback(PLAN, "question", "indicator");
     }
 
     public static PlanFeedback deletedPlanFeedback() {
-        return new PlanFeedback(PLAN, "question", "indicator",
-                LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now());
+        return new PlanFeedback(PLAN, "question", "indicator");
     }
 }


### PR DESCRIPTION
## #️⃣ Related Issue

Linked Feature backlog: 

## 📝 Purpose of PR

탈퇴 후 재가입 시 온보딩이 이루어지지 않던 오류 수정  

## Contents

- 탈퇴 후 재가입 시 온보딩이 이루어지지 않던 오류 수정  
- 비동기 이벤트 테스트 config 추가 

## Checklist

-   [ ] Does commit messages follow the convention?
-   [ ] Are variable names brief but descriptive?
-   [ ] Is the code clean and easy to understand?
-   [ ] If a new feature has been added, or a bug fixed, has a test been added to confirm good behavior?
-   [ ] Does the test successfully test edge and corner cases?

## 💬 Review Requirements (Optional)

Is there anything you can praise about this PR? Start with praise.
Make a review, leaving kind comments and suggesting changes where needed (to resolve the above).
